### PR TITLE
Fixed issue with paths not working on Windows OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,16 +20,17 @@ var ROOT = __dirname + '/';
 /**
  * set the current file in given path to name
  *
- * @param path
+ * @param srcPath
  * @param name
  *
  * @returns {string}
  */
-function changeFile (path, name) {
-    var parts = path.split('/');
+function changeFile (srcPath, name) {
+    var path = require('path');
+    var parts = srcPath.split(path.sep);
     parts.pop();
     parts.push(name);
-    return parts.join('/');
+    return parts.join(path.sep);
 }
 
 /**


### PR DESCRIPTION
The path was assumed to have forward slashes when it was being split. This resulted in the path being wrong on Windows where paths are backslashes. The fix was to use the Node.js path library and get the OS specific separator. This fixes the issue on Windows and Unix operating systems which use a forward slash are unaffected.

The error before applying this fix was:

```
node_modules\gulp-slate\index.js:189
throw new PluginError(
FileOpenError: could not open include includes/_errors.md
```
