### PR TITLE
Fix: Variables option should support both relative and absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,9 +103,11 @@ log.ERROR = 30;
 function buildAssets (opts, callback) {
     return new Promise(function (resolve) {
         var rawScss = [];
-        rawScss.push('@import "'+getModulePath('slate')+'/source/stylesheets/_variables.scss";');
         if (opts.variables) {
-            rawScss.push('@imports "'+opts.variables+'";');
+            if(!path.isAbsolute(opts.variables)) {
+                opts.variables = path.join(path.dirname(module.parent.filename), opts.variables);
+            }
+            rawScss.push('@import "'+opts.variables+'";');
         }
         rawScss.push('@function font-url($url){ @return url($url) }');
         rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');


### PR DESCRIPTION
Fixes #15

Allows both relative and absolute paths to be specified for the `variables` options.

Removes explicit import of Slate's own _variables.scss as Slate already imports this itself.

**The `variables` option still won't work until Slate changes its variables to only provide defaults:**

https://github.com/tripit/slate/pull/484
