### PR TITLE
Fix: Enable Slate's default variables to be used by gulp-slate's app.scss file

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ function buildAssets (opts, callback) {
             }
             rawScss.push('@import "'+opts.variables+'";');
         }
+        rawScss.push('@import "'+getModulePath('slate')+'/source/stylesheets/_variables.scss";');
         rawScss.push('@function font-url($url){ @return url($url) }');
         rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
         rawScss.push('@media screen { .highlight._{ @import "'+getModulePath('highlight.js')+'/../styles/solarized-light"; } }');

--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ function buildAssets (opts, callback) {
             rawScss.push('@import "'+opts.scss+'";');
         }
         else {
+            rawScss.push('@media screen { @import "'+getModulePath('gulp-slate')+'/src/app.scss"; }');
             rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
             rawScss.push('@media print { @import "'+getModulePath('slate')+'/source/stylesheets/print.css.scss"; }');
         }

--- a/index.js
+++ b/index.js
@@ -111,21 +111,22 @@ function buildAssets (opts, callback) {
         }
         rawScss.push('@import "'+getModulePath('slate')+'/source/stylesheets/_variables.scss";');
         rawScss.push('@function font-url($url){ @return url($url) }');
-        rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
-        rawScss.push('@media screen { .highlight._{ @import "'+getModulePath('highlight.js')+'/../styles/solarized-light"; } }');
-        rawScss.push('@media print { @import "'+getModulePath('slate')+'/source/stylesheets/print.css.scss"; }');
+
+        if (opts.scss) {
+            if(!path.isAbsolute(opts.scss)) {
+                opts.scss = path.join(path.dirname(module.parent.filename), opts.scss);
+            }
+            rawScss.push('@import "'+opts.scss+'";');
+        }
+        else {
+            rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
+            rawScss.push('@media print { @import "'+getModulePath('slate')+'/source/stylesheets/print.css.scss"; }');
+        }
+        rawScss.push('@media screen { @import "'+getModulePath('highlight.js')+'/../styles/'+opts.style+'.css'+'"; }');
 
         es.concat(
             gulp
-                .src(
-                    [
-                        opts.scss,
-                        getModulePath('highlight.js')+'/styles/'+opts.style+'.css'
-                    ],
-                    {
-                        base: '.'
-                    }
-                )
+                .src([])
                 .pipe(add('raw.scss', rawScss.join("\n"), true))
                 .pipe(concat("app.scss"))
                 .pipe(sass())
@@ -206,7 +207,7 @@ module.exports = function (opts) {
         filename: false,
         style: 'solarized-dark',
         template: ROOT+'src/layout.html',
-        scss: ROOT+'src/app.scss',
+        scss: null,
         variables: null,
         logo: getModulePath('slate')+'/source/images/logo.png',
         includeLoader: function (name, mainFile) {

--- a/index.js
+++ b/index.js
@@ -122,11 +122,12 @@ function buildAssets (opts, callback) {
             rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
             rawScss.push('@media print { @import "'+getModulePath('slate')+'/source/stylesheets/print.css.scss"; }');
         }
-        rawScss.push('@media screen { @import "'+getModulePath('highlight.js')+'/../styles/'+opts.style+'.css'+'"; }');
+
+        var styles_path = path.join(getModulePath('highlight.js'), '/../styles/', opts.style+'.css');
 
         es.concat(
             gulp
-                .src([])
+                .src([styles_path])
                 .pipe(add('raw.scss', rawScss.join("\n"), true))
                 .pipe(concat("app.scss"))
                 .pipe(sass())

--- a/index.js
+++ b/index.js
@@ -119,7 +119,6 @@ function buildAssets (opts, callback) {
             rawScss.push('@import "'+opts.scss+'";');
         }
         else {
-            rawScss.push('@media screen { @import "'+getModulePath('gulp-slate')+'/src/app.scss"; }');
             rawScss.push('@media screen { @import "'+getModulePath('slate')+'/source/stylesheets/screen.css.scss"; }');
             rawScss.push('@media print { @import "'+getModulePath('slate')+'/source/stylesheets/print.css.scss"; }');
         }


### PR DESCRIPTION
Apologies. I didn't realise that you were referencing Slate's default variables in gulp-slate's app.scss file and my last pull request broke things.

Specifically, app.scss references $phone-width.

This pull request make's Slate's default variables (or variables the user specifies instead) available to app.scss.
